### PR TITLE
Add better error handling for Google login failures

### DIFF
--- a/app/middlewares/passport.ts
+++ b/app/middlewares/passport.ts
@@ -35,7 +35,6 @@ async function googleLoginCallback(accessToken: string, refreshToken: string, pr
     const user = await getOrCreateUser({email, name: profile.displayName});
     done(null, user);
   } catch (error) {
-    // TODO: Verify that this works as expected
     done(error, null);
   }
 }

--- a/app/router.ts
+++ b/app/router.ts
@@ -89,7 +89,7 @@ function createAuthRouter(): Router {
       passport.authenticate('google-web',
         function(err, user, info) {
           if (err) {
-            res.redirect(process.env.WEB_LOGIN_FAILURE_REDIRECT!! + `?error=${err.message}`);
+            res.redirect(process.env.WEB_LOGIN_FAILURE_REDIRECT!! + `?error=${encodeURIComponent(err.message)}`);
             return;
           }
           req.logIn(user, function(err) {


### PR DESCRIPTION
Use redirects also with login failures and provide relevant error messages for both clients.

Is built on top of #75.

Is related to https://github.com/Parkdude/parkdude-mobile/issues/7.