### PR TITLE
Aws restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ First time deployment:
 3. First time setup needs to create CDKToolkit as a CloudFormation stack. This can be done using `cdk bootstrap aws://${numeric-identifier}/eu-north-1`. The \${numeric-identifier} is the AWS Account identifier that can be found on the AWS console's IAM page in format 012345678912.
 4. Deploy the code to AWS using: `npm run aws-deploy`.
 
-Updating changes to excisting stack:
+Updating changes to existing stack:
 
 1. Compile the code: `npm run build`.
-2. Re-generate the CloudFormation template code: `npm run synth`.
+2. Re-generate the CloudFormation template code if there are AWS stack changes: `npm run synth`.
 3. Deploy changes: `npm run aws-deploy`.
 
 ## Database migrations
@@ -153,5 +153,3 @@ ParkDude has two integrations with Slack. Slack webhooks are used to send notifi
 10. Redeploy Lambda for changes to take effect.
 
 If there ever comes a need to reset the signing secret, it can be done in the App Credentials section. The environment variable for lambda needs to be updated accordingly.
-
-

--- a/bin/parkdude-backend.ts
+++ b/bin/parkdude-backend.ts
@@ -4,4 +4,9 @@ import cdk = require('@aws-cdk/core');
 import {ParkdudeBackendStack} from '../lib/parkdude-backend-stack';
 
 const app = new cdk.App();
-new ParkdudeBackendStack(app, 'ParkdudeBackendStack');
+new ParkdudeBackendStack(app, 'ParkdudeBackendStack', {
+  env: {
+    // Must be same where cdk initialisations have been made (init creates CDK toolkit there).
+    region: 'eu-north-1'
+  }
+});

--- a/lib/parkdude-backend-stack.ts
+++ b/lib/parkdude-backend-stack.ts
@@ -31,7 +31,8 @@ export class ParkdudeBackendStack extends cdk.Stack {
           cidrMask: 28,
           name: 'Parkdude-Database'
         }
-      ]
+      ],
+      natGateways: 1
     });
 
     const parkdudeVPCSecGroup = new ec2.SecurityGroup(this, 'ParkdudeVPCSecGroup', {

--- a/lib/parkdude-backend-stack.ts
+++ b/lib/parkdude-backend-stack.ts
@@ -36,8 +36,7 @@ export class ParkdudeBackendStack extends cdk.Stack {
 
     const parkdudeVPCSecGroup = new ec2.SecurityGroup(this, 'ParkdudeVPCSecGroup', {
       vpc: parkdudeVpc,
-      // Temporarily allowing all traffic outside until more specific rules are created
-      allowAllOutbound: true // FIX ME!
+      allowAllOutbound: false
     });
 
     parkdudeVPCSecGroup.addIngressRule(
@@ -50,6 +49,18 @@ export class ParkdudeBackendStack extends cdk.Stack {
       ec2.Peer.ipv4('10.0.0.0/24'), // CIDR block for local VPC traffic
       ec2.Port.tcp(5432),
       'PostgreSQL default outbound port'
+    );
+
+    parkdudeVPCSecGroup.addEgressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(443),
+      'HTTPS default outbound port for Lambda'
+    );
+
+    parkdudeVPCSecGroup.addEgressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(80),
+      'HTTP default outbound port for Lambda'
     );
 
     // Automatically creates a password for database.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "typeorm:show": "npm run typeorm migration:show -- --config env/app.dev.env",
     "typeorm:migrate": "npm run typeorm migration:run -- --config env/app.dev.env",
     "typeorm:revert": "npm run typeorm migration:revert -- --config env/app.dev.env",
-    "aws-init": "cdk bootstrap",
+    "aws-init": "cdk bootstrap --region eu-north-1",
     "aws-build": "cdk synth ParkdudeBackendStack",
     "aws-deploy": "cdk deploy ParkdudeBackendStack",
     "aws-destroy": "cdk destroy ParkdudeBackendStack"


### PR DESCRIPTION
Limits outgoing VPC traffic and reduces NAT gateways to 1. Is based on earlier pull request by @lkananen.

Closes #39.