### PR TITLE
Reduce transaction durations

### DIFF
--- a/app/e2e-tests/parking-reservation.test.ts
+++ b/app/e2e-tests/parking-reservation.test.ts
@@ -2154,6 +2154,15 @@ describe('Parking reservations (e2e)', () => {
           })
           .expect(400, {message: 'Dates must be in format YYYY-MM-DD.'});
       });
+
+      test('Should give 404 if parking spot does not exist', async () => {
+        await agent.post('/api/parking-reservations')
+          .send({
+            dates: ['2019-11-01'],
+            parkingSpotId: '5e744477-c573-4856-9947-ec2500c7c0e2'
+          })
+          .expect(404, {message: 'Parking spot does not exist. It might have been removed.'});
+      });
     });
   });
 
@@ -2542,7 +2551,7 @@ describe('Parking reservations (e2e)', () => {
         await agent.delete(
           '/api/parking-reservations/parking-spot/5e744477-c573-4856-9947-ec2500c7c0e2?dates=2019-11-01'
         )
-          .expect(404, {message: 'Entity not found.'});
+          .expect(404, {message: 'Parking spot does not exist. It might have been removed.'});
       });
     });
   });

--- a/app/services/parking-reservation.service.ts
+++ b/app/services/parking-reservation.service.ts
@@ -197,8 +197,8 @@ export async function reserveSpots(
     ...await DayReservation.findByIds(reservationIds),
     ...removedReleases
   ];
-    // Sorting done here because there are two separate queries
-    // The number of results is not expected to be large.
+  // Sorting done here because there are two separate queries
+  // The number of results is not expected to be large.
   reservationsAndDeletedReleases.sort((a, b) => a.date < b.date ? -1 : 1);
   // Fail silently to not show user the error message
   await sendReservationSlackNotification(reservationsAndDeletedReleases, user).catch(() => {});

--- a/app/utils/errors.ts
+++ b/app/utils/errors.ts
@@ -22,6 +22,12 @@ export class ForbiddenError extends StatusError {
   }
 }
 
+export class NotFoundError extends StatusError {
+  constructor(message = 'Not found.') {
+    super(message, 404);
+  }
+}
+
 export class ReservationFailedError extends Error {
   constructor(message: string, public dates: string[]) {
     super(message);

--- a/env/app.dev.example.env
+++ b/env/app.dev.example.env
@@ -14,7 +14,7 @@ TYPEORM_MIGRATIONS = app/migrations/index.ts
 # schema changes are made, but should be disabled in production.
 TYPEORM_MIGRATIONS_RUN = true
 
-# Google oauth2 credentials
+# Google oauth2 credentials. See README for details.
 CLIENT_ID =
 CLIENT_SECRET =
 # Secret is used to hash sessions


### PR DESCRIPTION
 Reduce transaction durations and add better 404 handling to reservation/release. With shorter transactions conflicts are less likely between users.

- Remove Slack notification from transaction
- Remove some fetches from transactions, since they are not needed for operation integrity
- Add 404 check to reservation parking spots
- Add better 404 message for releases

Closes #82.

